### PR TITLE
Removing a repo that is not available

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -33,7 +33,6 @@ var optInRepos = [
   'dukpt',
   'splunk-auth-proxy',
   'magnet',
-  'googleTrustedShopifyStores',
   'goreferrer',
   'asset_cloud',
   'minesweeper'


### PR DESCRIPTION
googleTrustedShopifyStores looks unavailable. 
Google cache it on November 3. I am not sure if it is temporary or permanent removal. 
Anyway, the links in the documentation are returning 404.
