### PR TITLE
Remove googleTrustedShopifyStores from repo list

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -33,7 +33,6 @@ var optInRepos = [
   'dukpt',
   'splunk-auth-proxy',
   'magnet',
-  'googleTrustedShopifyStores',
   'goreferrer',
   'asset_cloud',
   'minesweeper'


### PR DESCRIPTION
Remove `googleTrustedShopifyStores` as the repo doesn't exist anymore.

Fixes #27 
