### PR TITLE
Add shipit-engine to the list of repos

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -41,7 +41,8 @@ var optInRepos = [
   'grizzly_ber',
   'semian',
   'go-lua',
-  'goluago'
+  'goluago',
+  'shipit-engine'
 ]
 
 // Add custom repos by full_name. Take the org/user and repo name


### PR DESCRIPTION
https://github.com/shopify/shipit-engine is now open source and we just posted an announcement blog post (https://www.shopify.com/technology/34281221-introducing-shipit).

Ping @cshold for review.