### PR TITLE
Liquid to ensure footer date is current

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
 
   <div class="grid">
     <div class="grid-item xlarge--one-third xlarge--text-left">
-      Built and maintained by <a href="http://www.shopify.com">Shopify Inc.</a> © 2014
+      Built and maintained by <a href="http://www.shopify.com">Shopify Inc.</a> © {{ site.time | date: "%Y" }}
     </div>
     <div class="grid-item xlarge--one-third">
       <a href="https://twitter.com/Shopify" class="twitter-link"><span class="under">Follow us</span> <i class="icon-twitter"></i></a>


### PR DESCRIPTION
The year in the site footer was listed as "2014". This PR adds a little Liquid to always print the current year -- or at least the year the site was last updated.

@cshold, does this look okay?