### PR TITLE
Add Theme Kit, Twine and Turbograft repos

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,4 +113,3 @@ description: As a team that greatly benefits from open-source software, these ar
 <script>
   var repos = {{ site.github.public_repositories | jsonify }};
 </script>
-

--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -45,6 +45,9 @@ var optInRepos = [
   'goluago',
   'shipit-engine',
   'pyreferrer',
+  'themekit',
+  'turbograft',
+  'twine',
 ]
 
 // Add custom repos by full_name. Take the org/user and repo name


### PR DESCRIPTION
Add in Theme Kit, Twine, and Turbograft, as they're both public and open but not listed. Any reason not to showcase any of these?

cc @m-ux @tylerball