### PR TITLE
use favicon from marketing assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Thumbs.db
 ######################
 *.sass-cache*
 /_site
+.ruby-version

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,7 +20,7 @@
 
 <meta property='st:title' content="{{ page.title }}">
 
-<link rel="shortcut icon" href="//cdn.shopify.com/assets/favicon.ico" type="image/x-icon">
+<link rel="shortcut icon" href="//cdn.shopify.com/shopify-marketing_assets/static/shopify-favicon.png" type="image/x-icon">
 
 <link href="css/main.css" rel="stylesheet" type="text/css">
 <!--[if lt IE 9]>


### PR DESCRIPTION
**Issue**: Site is using the old favicon.

I've switched it to use the one from marketing_assets.  Same approach as in the JS Buy SDK. https://shopify.github.io/js-buy-sdk/

Current: https://cdn.shopify.com/assets/favicon.ico
New: https://cdn.shopify.com/shopify-marketing_assets/static/shopify-favicon.png

![](http://take.ms/i0H9L)

---

Note: I'm using `RBENV`, so I added it to the list of ignores.