### PR TITLE
add slate framework and slate cli repos

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,4 +113,3 @@ description: As a team that greatly benefits from open-source software, these ar
 <script>
   var repos = {{ site.github.public_repositories | jsonify }};
 </script>
-

--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -15,6 +15,8 @@ var optInRepos = [
   'shopify_api',
   'sarama',
   'Timber',
+  'slate',
+  'slate-cli',
   'shopify-css-import',
   'active_fulfillment',
   'shopify_python_api',
@@ -60,6 +62,7 @@ var customRepos = [
 var customRepoLanguage = {
   'liquid': 'Liquid',
   'Timber': 'Liquid',
+  'slate': 'Liquid',
   'skeleton-theme': 'Liquid',
   'dashing': 'Ruby',
   'shopify_theme': 'Ruby',


### PR DESCRIPTION
Adding [Slate](https://github.com/Shopify/slate) and [Slate CLI](https://github.com/Shopify/slate-cli) to list.  (Won't merge until these are actually open - couple days max).

@macdonaldr93 Only adding Slate CLI, but not slate-tools and the rest.  No strong reasoning as to why though... think I should add Slate tools?

/cc @cshold @Shopify/themes-team 