### PR TITLE
Add kubernetes-deploy to the list of projects

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -62,7 +62,8 @@ var optInRepos = [
   'wolverine',
   'promise-kotlin',
   'promise-swift',
-  'android-testify'
+  'android-testify',
+  'kubernetes-deploy'
 ];
 
 // Add custom repos by full_name. Take the org/user and repo name


### PR DESCRIPTION
I noticed that we don't have `kubernetes-deploy` added to the list of open source projects. Let's add it!