### PR TITLE
Add krane by proper name, remove kubernetes-deploy

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -66,7 +66,7 @@ var optInRepos = [
   'promise-kotlin',
   'promise-swift',
   'android-testify',
-  'kubernetes-deploy',
+  'krane',
   'quilt',
   'graphql-tools-web'
 ];


### PR DESCRIPTION
Bit of an oversight. We should have https://github.com/Shopify/krane here.