### PR TITLE
Remove Verdict

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -61,7 +61,6 @@ var optInRepos = [
   'tslint-config-shopify',
   'turbograft',
   'twine',
-  'verdict',
   'voucher',
   'vouch4cluster',
   'wolverine',


### PR DESCRIPTION
Open source [Verdict](https://github.com/Shopify/verdict) is archived and no longer maintained.

Closes: https://github.com/Shopify/experiments/issues/532