### PR TITLE
Add Hydrogen to list of open source repos

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -19,6 +19,7 @@ var optInRepos = [
   'goluago',
   'goreferrer',
   'grizzly_ber',
+  'hydrogen',
   'identity_cache',
   'js-buy-sdk',
   'kubeaudit',


### PR DESCRIPTION
I noticed that our list of open source projects (https://shopify.github.io) doesn't include Hydrogen. Since the engineering blog links to that list and we'll have some blog posts coming out shortly related to it, I thought it would be important to add it. 