### PR TITLE
Add Tophat to repo list

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -54,6 +54,7 @@ var optInRepos = [
   'sync_app_demo',
   'sysv_mq',
   'tapioca',
+  'tophat',
   'toxiproxy',
   'toxiproxy-ruby',
   'turbograft',


### PR DESCRIPTION
Adding a new open source project, `Shopify/tophat` to the list of opted-in repos.