### PR TITLE
Fix rendering due to unescaped GitHub data

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,20 @@ description: As a team that greatly benefits from open-source software, these ar
 </script>
 
 <script>
-  var repos = {{ site.github.public_repositories | jsonify }};
+  var repos = [
+  {% for repo in site.github.public_repositories %}
+    {
+      name: "{{repo.name}}",
+      html_url: "{{repo.html_url}}",
+      description: "{{repo.description}}",
+      homepage: "{{repo.homepage}}",
+      language: "{{repo.language}}",
+      stargazers_count: {{repo.stargazers_count}},
+      forks_count: {{repo.forks_count}},
+      fork: {{repo.fork}}
+    },
+  {% endfor %}
+  ];
 </script>
 
 <div class="pagewidth">


### PR DESCRIPTION
Looks like there's some HTML being returned from the GitHub API (correctly, as part of the JSON payload) and using `jsonify` does not properly escape it when rendering to the page.  This essentially reverts this change from 2014 to only render the data we need to avoid this: #19