### PR TITLE
Escape repo descriptions from GitHub data

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@ description: As a team that greatly benefits from open-source software, these ar
     {
       name: "{{repo.name}}",
       html_url: "{{repo.html_url}}",
-      description: "{{repo.description}}",
+      description: "{{repo.description | escape}}",
       homepage: "{{repo.homepage}}",
       language: "{{repo.language}}",
       stargazers_count: {{repo.stargazers_count}},


### PR DESCRIPTION
Following up #124 with the addition of a missing escaped description which produced an invalid JavaScript object.