### PR TITLE
[ShopifyVM] add shopify-function-wasm-api public repo

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -48,6 +48,7 @@ var optInRepos = [
   'shopify_app',
   'shopify_django_app',
   'shopify_python_api',
+  'shopify-function-wasm-api',
   'splunk-auth-proxy',
   'spoom',
   'statsd-instrument',


### PR DESCRIPTION
Adds `shopify-function-wasm-api` as a public repo from guidance in vault.

Added as part of the `optIn` repos. But let me know if this should be a custom :) 

Issue to make repo public: https://github.com/Shopify/shopify-function-wasm-api/pull/43