### PR TITLE
Add the autosizes repo

### DIFF
--- a/javascripts/custom-repos.js
+++ b/javascripts/custom-repos.js
@@ -7,6 +7,7 @@ var optInRepos = [
   'active_utils',
   'app_profiler',
   'asset_cloud',
+  'autosizes',
   'better-html',
   'browser_sniffer',
   'dukpt',


### PR DESCRIPTION
I'm planning to open-source https://github.com/Shopify/autosizes and the process outlined in https://vault.shopify.io/page/Open-source~dhb2b7f.md#outgoing says I should add it to our list of projects :)